### PR TITLE
Rework Dockerfile for smaller binary. Adjust the user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
 # This Dockerfile uses two stages.
 # The first stage builds the binary.
 # The second stage executes the binary on default port 2222.
-# It is recommended to keep it on 2222 and use a DNAT.
+# It is recommended to keep the port on 2222 and use a DNAT.
 
 # Stage 1: Building
 # Use the Go Alpine image as building environment
 FROM docker.io/library/golang:alpine as builder
 # Create passwd here. scratch can not.
-RUN adduser -D -s /bin/false pitter
+RUN adduser -HDs /bin/false pitter
 WORKDIR /pit
+RUN apk add llvm
 COPY fortressh.go /pit
-RUN go build fortressh.go
+RUN go build fortressh.go && llvm-strip fortressh
 
 # Stage 2: Running
 # Run in minimal environment
 FROM scratch
 ENV LANG=C.UTF-8
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=pitter:pitter /pit/fortressh /fortressh
+COPY --from=builder --chown=pitter /pit/fortressh /fortressh
 # Always use an unprivileged user
 USER pitter
 # Expose the port


### PR DESCRIPTION
The binary is now stripped after compiling. With this extra step the final image is just 1.88 MB in size.
Also adjusted the non root user. When creating it in stage 1 we do not need a home dir. Furthermore we don't copy the /etc/group so there should not be a group specified when copying the binary.