### PR TITLE
Add an example docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ version: "3"
 services:
     fortressh:
         image: fortressh
+        cap_drop:
+          - "ALL"
         ports:
             - "10.2.0.1:2222:2222"
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# This docker-compose is just an example.
+version: "3"
+
+services:
+  fortressh:
+    image: localhost/fortressh:latest
+    cap_drop:
+      - "ALL"
+    ports:
+      - "10.2.0.1:2222:2222"
+    networks:
+      tarpit_subnet:
+        ipv4_address: 10.2.0.2
+    restart: unless-stopped
+
+networks:
+  tarpit_subnet:
+    external: true


### PR DESCRIPTION
This example docker-compose fits the the README.
Also added dropping all capabilities in the README. The container does not need any capabilities and should be as basic as possible.